### PR TITLE
feat: automatic HTML entity escaping

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -46,11 +46,15 @@
           
             <li><a href="#symbol-templatel-env-add-template">templatel-env-add-template</a></li>
           
+            <li><a href="#symbol-templatel-env-get-autoescape">templatel-env-get-autoescape</a></li>
+          
             <li><a href="#symbol-templatel-env-new">templatel-env-new</a></li>
           
             <li><a href="#symbol-templatel-env-remove-filter">templatel-env-remove-filter</a></li>
           
             <li><a href="#symbol-templatel-env-render">templatel-env-render</a></li>
+          
+            <li><a href="#symbol-templatel-env-set-autoescape">templatel-env-set-autoescape</a></li>
           
         </ul>
       
@@ -64,6 +68,8 @@
             <li><a href="#symbol-templatel-filters-lower">templatel-filters-lower</a></li>
           
             <li><a href="#symbol-templatel-filters-plus1">templatel-filters-plus1</a></li>
+          
+            <li><a href="#symbol-templatel-filters-safe">templatel-filters-safe</a></li>
           
             <li><a href="#symbol-templatel-filters-sum">templatel-filters-sum</a></li>
           
@@ -95,7 +101,7 @@
             
               <div class="symbol" id="symbol-templatel-render-file">
                 
-                  <h2>(templatel-render-file (path variables))</h2>
+                  <h2>(templatel-render-file (path variables &rest opt))</h2>
                 
 
                 
@@ -110,7 +116,36 @@ Just like with
 templates rendered with this function also can’t use <code>{% extends
 %}</code> statements.  Please refer to the section
 <a href="#section-template-environments">Template Environments</a>
-to learn how to use the API that enables template inheritance.</p>
+to learn how to use the API that enables template inheritance.
+</p>
+
+<p>
+Given the HTML template <code>file.html</code>:
+</p>
+<div class="org-src-container">
+<pre class="src src-jinja2">Hi <span class="org-type">{{</span> <span class="org-variable-name">name</span> <span class="org-type">}}</span>
+</pre>
+</div>
+
+<p>
+And the following Lisp code:
+</p>
+<div class="org-src-container">
+<pre class="src src-emacs-lisp">(templatel-render-file <span class="org-string">"file.html"</span> <span class="org-warning">&#8217;</span>((<span class="org-string">"name"</span> . <span class="org-string">"test"</span>)))
+</pre>
+</div>
+
+<p>
+The argument OPT can have the following entries:
+</p>
+
+<ul class="org-ul">
+<li><b>AUTOESCAPE-EXT</b>: list contains which file extensions enable</li>
+</ul>
+<p>
+automatic enabled HTML escaping.  In the example above, HTML
+entities present in ‘name‘ will be escaped.  Notice that the
+comparison is case sensitive.  Defaults to <code>’("html" "xml")</code>.</p>
 
                   </div>
                 
@@ -118,7 +153,7 @@ to learn how to use the API that enables template inheritance.</p>
             
               <div class="symbol" id="symbol-templatel-render-string">
                 
-                  <h2>(templatel-render-string (template variables))</h2>
+                  <h2>(templatel-render-string (template variables &rest options))</h2>
                 
 
                 
@@ -136,6 +171,15 @@ refer to the next section
 <a href="#section-template-environments">Template Environments</a>
 to learn how to use the API that enables template inheritance.
 </p>
+
+<p>
+The argument OPTIONS can have the following entries:
+</p>
+
+<ul class="org-ul">
+<li><b>AUTOESCAPE</b>: enables automatic HTML entity escaping.  Defaults
+to <code>nil</code>.</li>
+</ul>
 
 <div class="org-src-container">
 <pre class="src src-emacs-lisp">(templatel-render-string <span class="org-string">"Hello, {{ name }}!"</span> <span class="org-warning">&#8217;</span>((<span class="org-string">"name"</span> . <span class="org-string">"GNU!"</span>)))
@@ -201,6 +245,20 @@ to remove filters added with this function.</p>
                   <div class="docstring">
                     <p>
 Add TEMPLATE to ENV under key NAME.</p>
+
+                  </div>
+                
+              </div>
+            
+              <div class="symbol" id="symbol-templatel-env-get-autoescape">
+                
+                  <h2>(templatel-env-get-autoescape (env))</h2>
+                
+
+                
+                  <div class="docstring">
+                    <p>
+Get autoescape flag of ENV.</p>
 
                   </div>
                 
@@ -290,6 +348,20 @@ Render template NAME within ENV with VARS as parameters.</p>
                 
               </div>
             
+              <div class="symbol" id="symbol-templatel-env-set-autoescape">
+                
+                  <h2>(templatel-env-set-autoescape (env autoescape))</h2>
+                
+
+                
+                  <div class="docstring">
+                    <p>
+Set AUTOESCAPE flag of ENV to either true or false.</p>
+
+                  </div>
+                
+              </div>
+            
           </div>
         </article>
       
@@ -335,6 +407,41 @@ Lower case all chars of S.</p>
                   <div class="docstring">
                     <p>
 Add one to S.</p>
+
+                  </div>
+                
+              </div>
+            
+              <div class="symbol" id="symbol-templatel-filters-safe">
+                
+                  <h2>(templatel-filters-safe (s))</h2>
+                
+
+                
+                  <div class="docstring">
+                    <p>
+Mark string S as safe.
+</p>
+
+<p>
+That is useful if one wants to allow variables to contain HTML
+code.  e.g.:
+</p>
+
+<div class="org-src-container">
+<pre class="src src-emacs-lisp">(templatel-render-string <span class="org-string">"Hi {{ name|safe }}!"</span> <span class="org-warning">&#8217;</span>((<span class="org-string">"name"</span> . <span class="org-string">"&lt;b&gt;you&lt;/b&gt;"</span>)) t)
+</pre>
+</div>
+
+<p>
+The above snippet would output the HTML entities untouched even
+though the flag for auto escaping is true:
+</p>
+
+<div class="org-src-container">
+<pre class="src src-text">Hi &lt;b&gt;you&lt;/b&gt;!
+</pre>
+</div>
 
                   </div>
                 

--- a/templatel-tests.el
+++ b/templatel-tests.el
@@ -108,14 +108,32 @@
           (expected (cdr test)))
       (should (equal expected (templatel-escape-string input)))))
 
-  ;; Ensure it's correctly used in the template
+  ;; Comes disabled by default
   (should (equal
            (templatel-render-string
             "<p>{{ post }}</p>"
             '(("post" . "<script>alert(1)</script>")))
+           "<p><script>alert(1)</script></p>"))
+
+  ;; Can be enabled with the autoescape flag
+  (should (equal
+           (templatel-render-string
+            "<p>{{ post }}</p>"
+            '(("post" . "<script>alert(1)</script>"))
+            :autoescape t)
            "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>"))
 
-  ;; Test out the `safe` filter
+  ;; Test out the `safe` filter when auto escaping is enabled; should
+  ;; disable escaping locally
+  (should (equal
+           (templatel-render-string
+            "<p>{{ post|safe }}</p>"
+            '(("post" . "<script>alert(1)</script>"))
+            :autoescape t)
+           "<p><script>alert(1)</script></p>"))
+
+  ;; Test out the `safe` filter when auto escaping is disabled; should
+  ;; be a no-op
   (should (equal
            (templatel-render-string
             "<p>{{ post|safe }}</p>"
@@ -137,6 +155,7 @@
                             (templatel-env-add-template
                              e name
                              (templatel-new "{% block greeting %}Hello {{ name }}{% endblock %}"))))))
+    (templatel-env-set-autoescape env t)
     ;; The override that calls super also didn't escape anything
     (templatel-env-add-template
      env "page.html"
@@ -152,6 +171,7 @@
                             (templatel-env-add-template
                              e name
                              (templatel-new "{% block greeting %}Hello {{ name|safe }}{% endblock %}"))))))
+    (templatel-env-set-autoescape env t)
     ;; The override that calls super trusts what the base template did
     (templatel-env-add-template
      env "page.html"
@@ -167,6 +187,7 @@
                             (templatel-env-add-template
                              e name
                              (templatel-new "{% block greeting %}Hello {{ name }}{% endblock %}"))))))
+    (templatel-env-set-autoescape env t)
     ;; The override that calls super trusts what the base template did
     (templatel-env-add-template
      env "page.html"

--- a/templatel-tests.el
+++ b/templatel-tests.el
@@ -115,6 +115,13 @@
             '(("post" . "<script>alert(1)</script>")))
            "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>"))
 
+  ;; Test out the `safe` filter
+  (should (equal
+           (templatel-render-string
+            "<p>{{ post|safe }}</p>"
+            '(("post" . "<script>alert(1)</script>")))
+           "<p><script>alert(1)</script></p>"))
+
   ;; Disable autoescaping
   (let ((env (templatel-env-new)))
     (templatel-env-set-autoescape env nil)

--- a/templatel.el
+++ b/templatel.el
@@ -1377,11 +1377,12 @@ call `templatel--compiler-filter-item' on each entry."
 This mostly handles autoescaping of values.  If the string is a
 safe string.  e.g.: `(safe . x)' then it is just printed out.
 Otherwise its HTML entities are escaped."
-  (if (templatel-env-get-autoescape env)
-      (pcase value
-        (`(safe . ,x) x)
-        (x (templatel-escape-string (format "%s" x))))
-    (format "%s" value)))
+  (let ((fn (if (templatel-env-get-autoescape env)
+                #'templatel-escape-string
+              #'identity)))
+    (pcase value
+      (`(safe . ,x) x)
+      (x (funcall fn (format "%s" x))))))
 
 (defun templatel--compiler-text (tree)
   "Compile text from TREE."


### PR DESCRIPTION
This refers to issue #4 and adds automatic escaping of HTML entities within text passed through variables to a template. e.g.:

```emacs-lisp
(templatel-render-string "<p>{{ post }}</p>" '(("post" . "<script>alert(1)</script>")) :autoescape t)
;; "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>"
```

It is also possible to locally disable the auto escaping using the `safe` filter:

```emacs-lisp
(templatel-render-string "<p>{{ post|safe }}</p>" '(("post" . "<script>alert(1)</script>")) :autoescape t)
;; "<p><script>alert(1)</script></p>"
```

Auto escaping comes disabled by default for `templatel-render-string` but comes enabled by default for HTML and XML files in the function `templatel-render-file`. Control auto escaping with `templatel-env-set-autoescape` when an environment is created with `templatel-env-new`.